### PR TITLE
Builtin poseidon

### DIFF
--- a/circuits/src/util.rs
+++ b/circuits/src/util.rs
@@ -617,6 +617,8 @@ pub fn generate_builtins_cmp_trace<F: RichField>(
             new_row_len = trace_len.next_power_of_two();
         }
 
+        new_row_len = max(2, new_row_len);
+
         // padding for exe trace
         //if !max_trace_len.is_power_of_two() {
         //let new_row_len = max_trace_len.next_power_of_two();


### PR DESCRIPTION
fixed generate error for cmp module