### PR TITLE
chore: update vitalik blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ OlaVM runs based on the Goldilocks field and uses STARK to generate proofs for t
 
 ### Vitalik Buterin's blog series on zk-STARKs:
 
-- [Part-1](https://vitalik.ca/general/2017/11/09/starks_part_1.html): Proofs with Polynomials
-- [Part-2](https://vitalik.ca/general/2017/11/22/starks_part_2.html): Thank Goodness It's FRI-day
-- [Part-3](https://vitalik.ca/general/2018/07/21/starks_part_3.html): Into the Weeds
+- [Part-1](https://vitalik.eth.limo/general/2017/11/09/starks_part_1.html): Proofs with Polynomials
+- [Part-2](https://vitalik.eth.limo/general/2017/11/22/starks_part_2.html): Thank Goodness It's FRI-day
+- [Part-3](https://vitalik.eth.limo/general/2018/07/21/starks_part_3.html): Into the Weeds
 
 ### Alan Szepieniec's STARK tutorials:
 


### PR DESCRIPTION
This PR updates Vitalik blog link as it moves to a new domain. source: https://github.com/vbuterin/blog

Note: Not sure whether to commit this change to `testnet-alpha` or `main`.  If you prefer this change committed to `main`, I'm happy to assist.
: )