### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/mini-ola-release.yml
+++ b/.github/workflows/mini-ola-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive   
     - name: Install Rust
@@ -39,7 +39,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive   
     - name: Install Rust
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest-xlarge
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive  
     - name: Install Rust
@@ -81,7 +81,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive   
     - name: Install Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache Rust toolchain
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected