### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/mini-ola-release.yml
+++ b/.github/workflows/mini-ola-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         submodules: recursive   
     - name: Install Rust
@@ -39,7 +39,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         submodules: recursive   
     - name: Install Rust
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest-xlarge
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         submodules: recursive  
     - name: Install Rust
@@ -81,7 +81,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         submodules: recursive   
     - name: Install Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Cache Rust toolchain
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0