### PR TITLE
fix: use correct clock cycle in prophet memory trace

### DIFF
--- a/executor/src/contract_executor.rs
+++ b/executor/src/contract_executor.rs
@@ -1712,7 +1712,7 @@ impl OlaContractExecutor {
                         value: value.get_number() as u64,
                     };
                     let trace_diff = MemExePiece {
-                        clk: 0,
+                        clk: self.clk,
                         addr: self.memory.psp(),
                         value: value.get_number() as u64,
                         is_write: true,


### PR DESCRIPTION
Fix incorrect clk value in MemExePiece generated by process_prophet.
Changed from hardcoded 0 to self.clk to match the pattern used in all
other trace operations and ensure proper clock cycle sequencing for
trace validation.